### PR TITLE
Migrate to js-promise

### DIFF
--- a/sandbox/Sandbox.purs
+++ b/sandbox/Sandbox.purs
@@ -86,7 +86,7 @@ import Web.HTML (window)
 import Web.HTML.HTMLCanvasElement (fromElement, height, width)
 import Web.HTML.HTMLDocument (toNonElementParentNode)
 import Web.HTML.Window (document, navigator, requestAnimationFrame)
-import Web.Promise as Web.Promise
+import Promise as Promise
 
 averager :: forall a. EuclideanRing a => Effect (a -> Effect a)
 averager = do
@@ -105,7 +105,7 @@ hackyFloatConv = unsafeCoerce
 hackyIntConv :: Array Int -> Array UInt
 hackyIntConv = unsafeCoerce
 
-convertPromise :: Web.Promise.Promise ~> Control.Promise.Promise
+convertPromise :: Promise.Promise ~> Control.Promise.Promise
 convertPromise = unsafeCoerce
 
 -- a port of alaingalvan/webgpu-seed
@@ -517,7 +517,7 @@ fn main(@builtin(global_invocation_id) global_id : vec3<u32>) {
 @group(0) @binding(0) var<storage, read_write> resultMatrix : array<f32>;
 @group(1) @binding(0) var<storage, read> time : f32;
 fn xyt2trig(x: u32, y: u32, time: f32) -> f32 {
-  const pi = 3.14159; 
+  const pi = 3.14159;
   var o = (x << 1) + y;
   return sin((time * pi) + (f32((o + 1) % 3) * (pi / 2.0)));
 }
@@ -1052,7 +1052,7 @@ fn main(@location(0) inColor: vec3<f32>) -> @location(0) vec4<f32> {
         end passEncoder
         --------
         -- write to output buffer
-        -- we use this as a test 
+        -- we use this as a test
         copyBufferToBuffer commandEncoder perspectiveResultBuffer 0
           buf
           0

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,15 +1,3 @@
-{-
-Welcome to a Spago project!
-You can edit this file as you like.
-
-Need help? See the following resources:
-- Spago documentation: https://github.com/purescript/spago
-- Dhall language tour: https://docs.dhall-lang.org/tutorials/Language-Tour.html
-
-When creating a new Spago project, you can use
-`spago init --no-comments` or `spago init -C`
-to generate this file without the comments in this block.
--}
 { name = "webgpu"
 , dependencies =
   [ "arraybuffer-types"
@@ -18,6 +6,7 @@ to generate this file without the comments in this block.
   , "foreign-object"
   , "functions"
   , "integers"
+  , "js-promise"
   , "maybe"
   , "newtype"
   , "ordered-collections"
@@ -26,7 +15,6 @@ to generate this file without the comments in this block.
   , "unsafe-coerce"
   , "web-events"
   , "web-html"
-  , "web-promise"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs" ]

--- a/src/Web/GPU/GPU.purs
+++ b/src/Web/GPU/GPU.purs
@@ -7,18 +7,22 @@ module Web.GPU.GPU
   ) where
 
 import Data.Maybe (Maybe(..))
-import Effect.Uncurried(EffectFn1, runEffectFn1,EffectFn4, runEffectFn4)
+import Effect.Uncurried (EffectFn1, runEffectFn1, EffectFn4, runEffectFn4)
 import Effect (Effect)
 import Web.GPU.GPURequestAdapterOptions (GPURequestAdapterOptions)
 import Web.GPU.GPUTextureFormat (GPUTextureFormat)
-import Web.Promise (Promise)
+import Promise (Promise)
 import Web.GPU.GPUAdapter (GPUAdapter)
 
 data GPU
 
 -- requestAdapter
 
-foreign import requestAdapterImpl :: EffectFn4 (GPUAdapter -> Maybe GPUAdapter) (Maybe GPUAdapter) GPU GPURequestAdapterOptions  (Promise (Maybe GPUAdapter))
+foreign import requestAdapterImpl
+  :: EffectFn4 (GPUAdapter -> Maybe GPUAdapter) (Maybe GPUAdapter) GPU
+       GPURequestAdapterOptions
+       (Promise (Maybe GPUAdapter))
+
 requestAdapter
   :: GPU
   -> GPURequestAdapterOptions
@@ -27,6 +31,7 @@ requestAdapter a b = runEffectFn4 requestAdapterImpl Just Nothing a b
 
 -- getPreferredCanvasFormat
 
-foreign import getPreferredCanvasFormatImpl :: EffectFn1 GPU  GPUTextureFormat
+foreign import getPreferredCanvasFormatImpl :: EffectFn1 GPU GPUTextureFormat
+
 getPreferredCanvasFormat :: GPU -> Effect GPUTextureFormat
 getPreferredCanvasFormat a = runEffectFn1 getPreferredCanvasFormatImpl a

--- a/src/Web/GPU/GPUAdapter.purs
+++ b/src/Web/GPU/GPUAdapter.purs
@@ -14,7 +14,7 @@ module Web.GPU.GPUAdapter
   ) where
 
 import Data.Maybe (Maybe(..))
-import Effect.Uncurried(EffectFn1, runEffectFn1,EffectFn2, runEffectFn2,EffectFn3, runEffectFn3,EffectFn4, runEffectFn4)
+import Effect.Uncurried (EffectFn1, runEffectFn1, EffectFn2, runEffectFn2, EffectFn3, runEffectFn3, EffectFn4, runEffectFn4)
 import Data.Set as Set
 import Effect (Effect)
 import Web.GPU.GPUDeviceDescriptor (GPUDeviceDescriptor)
@@ -22,35 +22,49 @@ import Web.GPU.GPUFeatureName (GPUFeatureName)
 import Web.GPU.GPUDevice (GPUDevice)
 import Web.GPU.GPUSupportedLimits (GPUSupportedLimits)
 import Web.GPU.UnmaskHint (UnmaskHint)
-import Web.Promise (Promise)
+import Promise (Promise)
 
 data GPUAdapter
 
 -- features
-foreign import featuresImpl :: EffectFn3 (GPUFeatureName -> Set.Set GPUFeatureName -> Set.Set GPUFeatureName) (Set.Set GPUFeatureName) GPUAdapter  (Set.Set GPUFeatureName)
+foreign import featuresImpl
+  :: EffectFn3
+       (GPUFeatureName -> Set.Set GPUFeatureName -> Set.Set GPUFeatureName)
+       (Set.Set GPUFeatureName)
+       GPUAdapter
+       (Set.Set GPUFeatureName)
+
 features :: GPUAdapter -> Effect (Set.Set GPUFeatureName)
 features a = runEffectFn3 featuresImpl Set.insert Set.empty a
 
-foreign import limitsImpl :: EffectFn1 GPUAdapter  { | GPUSupportedLimits }
+foreign import limitsImpl :: EffectFn1 GPUAdapter { | GPUSupportedLimits }
+
 limits :: GPUAdapter -> Effect { | GPUSupportedLimits }
 limits a = runEffectFn1 limitsImpl a
 
-foreign import isFallbackAdapterImpl :: EffectFn1 GPUAdapter  Boolean
+foreign import isFallbackAdapterImpl :: EffectFn1 GPUAdapter Boolean
+
 isFallbackAdapter :: GPUAdapter -> Effect Boolean
 isFallbackAdapter a = runEffectFn1 isFallbackAdapterImpl a
 
 -- requestDevice
 
-foreign import requestDeviceImpl :: EffectFn4 (GPUDevice -> Maybe GPUDevice)( Maybe GPUDevice) GPUAdapter GPUDeviceDescriptor  (Promise (Maybe GPUDevice))
+foreign import requestDeviceImpl
+  :: EffectFn4 (GPUDevice -> Maybe GPUDevice) (Maybe GPUDevice) GPUAdapter
+       GPUDeviceDescriptor
+       (Promise (Maybe GPUDevice))
+
 requestDevice
   :: GPUAdapter
   -> GPUDeviceDescriptor
   -> Effect (Promise (Maybe GPUDevice))
-requestDevice a b= runEffectFn4 requestDeviceImpl Just Nothing a b
+requestDevice a b = runEffectFn4 requestDeviceImpl Just Nothing a b
 
 -- requestAdapterInfo
 
-foreign import requestAdapterInfoImpl :: EffectFn2 GPUAdapter (Array UnmaskHint)  (Promise GPUAdapterInfo)
+foreign import requestAdapterInfoImpl
+  :: EffectFn2 GPUAdapter (Array UnmaskHint) (Promise GPUAdapterInfo)
+
 type GPUAdapterInfo =
   { vendor :: String
   , architecture :: String

--- a/src/Web/GPU/GPUBuffer.purs
+++ b/src/Web/GPU/GPUBuffer.purs
@@ -29,7 +29,7 @@ module Web.GPU.GPUBuffer
   ) where
 
 import Prelude
-import Effect.Uncurried(EffectFn1, runEffectFn1,EffectFn2, runEffectFn2,EffectFn3, runEffectFn3,EffectFn4, runEffectFn4)
+import Effect.Uncurried (EffectFn1, runEffectFn1, EffectFn2, runEffectFn2, EffectFn3, runEffectFn3, EffectFn4, runEffectFn4)
 
 import Data.ArrayBuffer.Types (ArrayBuffer)
 import Effect (Effect)
@@ -37,62 +37,88 @@ import Web.GPU.GPUBufferMapState (GPUBufferMapState)
 import Web.GPU.GPUBufferUsage (GPUBufferUsage)
 import Web.GPU.GPUMapMode (GPUMapMode)
 import Web.GPU.Internal.Types (GPUSize64)
-import Web.Promise (Promise)
+import Promise (Promise)
 
 data GPUBuffer
 
-foreign import sizeImpl :: EffectFn1 GPUBuffer  GPUSize64
+foreign import sizeImpl :: EffectFn1 GPUBuffer GPUSize64
+
 size :: GPUBuffer -> Effect GPUSize64
 size a = runEffectFn1 sizeImpl a
 
-foreign import usageImpl :: EffectFn1 GPUBuffer  GPUBufferUsage
+foreign import usageImpl :: EffectFn1 GPUBuffer GPUBufferUsage
+
 usage :: GPUBuffer -> Effect GPUBufferUsage
 usage a = runEffectFn1 usageImpl a
 
-foreign import mapStateImpl :: EffectFn1 GPUBuffer  GPUBufferMapState
+foreign import mapStateImpl :: EffectFn1 GPUBuffer GPUBufferMapState
+
 mapState :: GPUBuffer -> Effect GPUBufferMapState
 mapState a = runEffectFn1 mapStateImpl a
 
-foreign import mapAsyncImpl :: EffectFn2 GPUBuffer GPUMapMode  (Promise Unit)
+foreign import mapAsyncImpl :: EffectFn2 GPUBuffer GPUMapMode (Promise Unit)
+
 mapAsync :: GPUBuffer -> GPUMapMode -> Effect (Promise Unit)
 mapAsync a b = runEffectFn2 mapAsyncImpl a b
 
-foreign import mapAsyncWithOffsetImpl :: EffectFn3 GPUBuffer GPUMapMode GPUSize64  (Promise Unit)
+foreign import mapAsyncWithOffsetImpl
+  :: EffectFn3 GPUBuffer GPUMapMode GPUSize64 (Promise Unit)
+
 mapAsyncWithOffset
   :: GPUBuffer -> GPUMapMode -> GPUSize64 -> Effect (Promise Unit)
 mapAsyncWithOffset a b c = runEffectFn3 mapAsyncWithOffsetImpl a b c
 
-foreign import mapAsyncWithSizeImpl :: EffectFn3 GPUBuffer GPUMapMode GPUSize64  (Promise Unit)
+foreign import mapAsyncWithSizeImpl
+  :: EffectFn3 GPUBuffer GPUMapMode GPUSize64 (Promise Unit)
+
 mapAsyncWithSize
   :: GPUBuffer -> GPUMapMode -> GPUSize64 -> Effect (Promise Unit)
 mapAsyncWithSize a b c = runEffectFn3 mapAsyncWithSizeImpl a b c
 
-foreign import mapAsyncWithOffsetAndSizeImpl :: EffectFn4 GPUBuffer GPUMapMode GPUSize64 GPUSize64  (Promise Unit)
+foreign import mapAsyncWithOffsetAndSizeImpl
+  :: EffectFn4 GPUBuffer GPUMapMode GPUSize64 GPUSize64 (Promise Unit)
+
 mapAsyncWithOffsetAndSize
   :: GPUBuffer -> GPUMapMode -> GPUSize64 -> GPUSize64 -> Effect (Promise Unit)
-mapAsyncWithOffsetAndSize a b c d = runEffectFn4 mapAsyncWithOffsetAndSizeImpl a b c d
+mapAsyncWithOffsetAndSize a b c d = runEffectFn4 mapAsyncWithOffsetAndSizeImpl a
+  b
+  c
+  d
 
-foreign import getMappedRangeImpl :: EffectFn1 GPUBuffer  ArrayBuffer
+foreign import getMappedRangeImpl :: EffectFn1 GPUBuffer ArrayBuffer
+
 getMappedRange :: GPUBuffer -> Effect ArrayBuffer
 getMappedRange a = runEffectFn1 getMappedRangeImpl a
 
-foreign import getMappedRangeWithOffsetImpl :: EffectFn2 GPUBuffer GPUSize64  ArrayBuffer
+foreign import getMappedRangeWithOffsetImpl
+  :: EffectFn2 GPUBuffer GPUSize64 ArrayBuffer
+
 getMappedRangeWithOffset :: GPUBuffer -> GPUSize64 -> Effect ArrayBuffer
 getMappedRangeWithOffset a b = runEffectFn2 getMappedRangeWithOffsetImpl a b
 
-foreign import getMappedRangeWithSizeImpl :: EffectFn2 GPUBuffer GPUSize64  ArrayBuffer
+foreign import getMappedRangeWithSizeImpl
+  :: EffectFn2 GPUBuffer GPUSize64 ArrayBuffer
+
 getMappedRangeWithSize :: GPUBuffer -> GPUSize64 -> Effect ArrayBuffer
 getMappedRangeWithSize a b = runEffectFn2 getMappedRangeWithSizeImpl a b
 
-foreign import getMappedRangeWithOffsetAndSizeImpl :: EffectFn3 GPUBuffer GPUSize64 GPUSize64  ArrayBuffer
+foreign import getMappedRangeWithOffsetAndSizeImpl
+  :: EffectFn3 GPUBuffer GPUSize64 GPUSize64 ArrayBuffer
+
 getMappedRangeWithOffsetAndSize
   :: GPUBuffer -> GPUSize64 -> GPUSize64 -> Effect ArrayBuffer
-getMappedRangeWithOffsetAndSize a b c = runEffectFn3 getMappedRangeWithOffsetAndSizeImpl a b c
+getMappedRangeWithOffsetAndSize a b c = runEffectFn3
+  getMappedRangeWithOffsetAndSizeImpl
+  a
+  b
+  c
 
-foreign import unmapImpl :: EffectFn1 GPUBuffer  Unit
+foreign import unmapImpl :: EffectFn1 GPUBuffer Unit
+
 unmap :: GPUBuffer -> Effect Unit
 unmap a = runEffectFn1 unmapImpl a
 
-foreign import destroyImpl :: EffectFn1 GPUBuffer  Unit
+foreign import destroyImpl :: EffectFn1 GPUBuffer Unit
+
 destroy :: GPUBuffer -> Effect Unit
 destroy a = runEffectFn1 destroyImpl a

--- a/src/Web/GPU/GPUDevice.purs
+++ b/src/Web/GPU/GPUDevice.purs
@@ -77,34 +77,45 @@ import Web.GPU.GPUShaderModuleDescriptor (GPUShaderModuleDescriptor)
 import Web.GPU.GPUSupportedLimits (GPUSupportedLimits)
 import Web.GPU.GPUTexture (GPUTexture)
 import Web.GPU.GPUTextureDescriptor (GPUTextureDescriptor)
-import Web.Promise (Promise)
+import Promise (Promise)
 
 data GPUDevice
 
 -- features
-foreign import featuresImpl :: EffectFn3 (GPUFeatureName -> Set.Set GPUFeatureName -> Set.Set GPUFeatureName) (Set.Set GPUFeatureName) GPUDevice  (Set.Set GPUFeatureName)
+foreign import featuresImpl
+  :: EffectFn3
+       (GPUFeatureName -> Set.Set GPUFeatureName -> Set.Set GPUFeatureName)
+       (Set.Set GPUFeatureName)
+       GPUDevice
+       (Set.Set GPUFeatureName)
+
 features :: GPUDevice -> Effect (Set.Set GPUFeatureName)
 features a = runEffectFn3 featuresImpl Set.insert Set.empty a
 
 -- limits
-foreign import limitsImpl :: EffectFn1 GPUDevice  { | GPUSupportedLimits }
+foreign import limitsImpl :: EffectFn1 GPUDevice { | GPUSupportedLimits }
+
 limits :: GPUDevice -> Effect { | GPUSupportedLimits }
 limits a = runEffectFn1 limitsImpl a
 
 -- queue
 
-foreign import queueImpl :: EffectFn1 GPUDevice  GPUQueue
+foreign import queueImpl :: EffectFn1 GPUDevice GPUQueue
+
 queue :: GPUDevice -> Effect GPUQueue
 queue a = runEffectFn1 queueImpl a
 
 -- destroy
 
-foreign import destroyImpl :: EffectFn1 GPUDevice  Unit
+foreign import destroyImpl :: EffectFn1 GPUDevice Unit
+
 destroy :: GPUDevice -> Effect Unit
 destroy a = runEffectFn1 destroyImpl a
 
 -- createBuffer
-foreign import createBufferImpl :: EffectFn2 GPUDevice GPUBufferDescriptor  GPUBuffer
+foreign import createBufferImpl
+  :: EffectFn2 GPUDevice GPUBufferDescriptor GPUBuffer
+
 createBuffer
   :: GPUDevice
   -> GPUBufferDescriptor
@@ -112,7 +123,9 @@ createBuffer
 createBuffer a b = runEffectFn2 createBufferImpl a b
 
 -- createTexture
-foreign import createTextureImpl :: EffectFn2 GPUDevice GPUTextureDescriptor  GPUTexture
+foreign import createTextureImpl
+  :: EffectFn2 GPUDevice GPUTextureDescriptor GPUTexture
+
 createTexture
   :: GPUDevice
   -> GPUTextureDescriptor
@@ -121,7 +134,9 @@ createTexture a b = runEffectFn2 createTextureImpl a b
 
 -- createSampler
 
-foreign import createSamplerImpl :: EffectFn2 GPUDevice GPUSamplerDescriptor  GPUSampler
+foreign import createSamplerImpl
+  :: EffectFn2 GPUDevice GPUSamplerDescriptor GPUSampler
+
 createSampler
   :: GPUDevice
   -> GPUSamplerDescriptor
@@ -130,7 +145,9 @@ createSampler a b = runEffectFn2 createSamplerImpl a b
 
 -- importExternalTexture
 
-foreign import importExternalTextureImpl :: EffectFn2 GPUDevice GPUExternalTextureDescriptor  GPUExternalTexture
+foreign import importExternalTextureImpl
+  :: EffectFn2 GPUDevice GPUExternalTextureDescriptor GPUExternalTexture
+
 importExternalTexture
   :: GPUDevice
   -> GPUExternalTextureDescriptor
@@ -139,7 +156,9 @@ importExternalTexture a b = runEffectFn2 importExternalTextureImpl a b
 
 -- createBindGroupLayout
 
-foreign import createBindGroupLayoutImpl :: EffectFn2 GPUDevice GPUBindGroupLayoutDescriptor  GPUBindGroupLayout
+foreign import createBindGroupLayoutImpl
+  :: EffectFn2 GPUDevice GPUBindGroupLayoutDescriptor GPUBindGroupLayout
+
 createBindGroupLayout
   :: GPUDevice
   -> GPUBindGroupLayoutDescriptor
@@ -148,7 +167,9 @@ createBindGroupLayout a b = runEffectFn2 createBindGroupLayoutImpl a b
 
 -- createPipelineLayout
 
-foreign import createPipelineLayoutImpl :: EffectFn2 GPUDevice GPUPipelineLayoutDescriptor  GPUPipelineLayout
+foreign import createPipelineLayoutImpl
+  :: EffectFn2 GPUDevice GPUPipelineLayoutDescriptor GPUPipelineLayout
+
 createPipelineLayout
   :: GPUDevice
   -> GPUPipelineLayoutDescriptor
@@ -157,13 +178,17 @@ createPipelineLayout a b = runEffectFn2 createPipelineLayoutImpl a b
 
 -- createBindGroup
 
-foreign import createBindGroupImpl :: EffectFn2 GPUDevice GPUBindGroupDescriptor  GPUBindGroup
+foreign import createBindGroupImpl
+  :: EffectFn2 GPUDevice GPUBindGroupDescriptor GPUBindGroup
+
 createBindGroup :: GPUDevice -> GPUBindGroupDescriptor -> Effect GPUBindGroup
 createBindGroup a b = runEffectFn2 createBindGroupImpl a b
 
 -- createShaderModule
 
-foreign import createShaderModuleImpl :: EffectFn2 GPUDevice GPUShaderModuleDescriptor  GPUShaderModule
+foreign import createShaderModuleImpl
+  :: EffectFn2 GPUDevice GPUShaderModuleDescriptor GPUShaderModule
+
 createShaderModule
   :: GPUDevice
   -> GPUShaderModuleDescriptor
@@ -171,7 +196,9 @@ createShaderModule
 createShaderModule a b = runEffectFn2 createShaderModuleImpl a b
 
 -- createComputePipeline
-foreign import createComputePipelineImpl :: EffectFn2 GPUDevice GPUComputePipelineDescriptor  GPUComputePipeline
+foreign import createComputePipelineImpl
+  :: EffectFn2 GPUDevice GPUComputePipelineDescriptor GPUComputePipeline
+
 createComputePipeline
   :: GPUDevice
   -> GPUComputePipelineDescriptor
@@ -180,7 +207,9 @@ createComputePipeline a b = runEffectFn2 createComputePipelineImpl a b
 
 -- createRenderPipeline
 
-foreign import createRenderPipelineImpl :: EffectFn2 GPUDevice GPURenderPipelineDescriptor  GPURenderPipeline
+foreign import createRenderPipelineImpl
+  :: EffectFn2 GPUDevice GPURenderPipelineDescriptor GPURenderPipeline
+
 createRenderPipeline
   :: GPUDevice
   -> GPURenderPipelineDescriptor
@@ -188,7 +217,10 @@ createRenderPipeline
 createRenderPipeline a b = runEffectFn2 createRenderPipelineImpl a b
 
 -- createComputePipelineAsnyc
-foreign import createComputePipelineAsyncImpl :: EffectFn2 GPUDevice GPUComputePipelineDescriptor  (Promise GPUComputePipeline)
+foreign import createComputePipelineAsyncImpl
+  :: EffectFn2 GPUDevice GPUComputePipelineDescriptor
+       (Promise GPUComputePipeline)
+
 createComputePipelineAsnyc
   :: GPUDevice
   -> GPUComputePipelineDescriptor
@@ -197,7 +229,9 @@ createComputePipelineAsnyc a b = runEffectFn2 createComputePipelineAsyncImpl a b
 
 -- createRenderPipelineAsync
 
-foreign import createRenderPipelineAsyncImpl :: EffectFn2 GPUDevice GPURenderPipelineDescriptor  (Promise GPURenderPipeline)
+foreign import createRenderPipelineAsyncImpl
+  :: EffectFn2 GPUDevice GPURenderPipelineDescriptor (Promise GPURenderPipeline)
+
 createRenderPipelineAsync
   :: GPUDevice
   -> GPURenderPipelineDescriptor
@@ -206,14 +240,18 @@ createRenderPipelineAsync a b = runEffectFn2 createRenderPipelineAsyncImpl a b
 
 -- createCommandEncoder
 
-foreign import createCommandEncoderImpl :: EffectFn2 GPUDevice GPUCommandEncoderDescriptor  GPUCommandEncoder
+foreign import createCommandEncoderImpl
+  :: EffectFn2 GPUDevice GPUCommandEncoderDescriptor GPUCommandEncoder
+
 createCommandEncoder
   :: GPUDevice -> GPUCommandEncoderDescriptor -> Effect GPUCommandEncoder
 createCommandEncoder a b = runEffectFn2 createCommandEncoderImpl a b
 
 -- createRenderBundleEncoder
 
-foreign import createRenderBundleEncoderImpl :: EffectFn2 GPUDevice GPURenderBundleEncoderDescriptor  GPUBuffer
+foreign import createRenderBundleEncoderImpl
+  :: EffectFn2 GPUDevice GPURenderBundleEncoderDescriptor GPUBuffer
+
 createRenderBundleEncoder
   :: GPUDevice
   -> GPURenderBundleEncoderDescriptor
@@ -222,7 +260,9 @@ createRenderBundleEncoder a b = runEffectFn2 createRenderBundleEncoderImpl a b
 
 -- createQuerySet
 
-foreign import createQuerySetImpl :: EffectFn2 GPUDevice GPUQuerySetDescriptor  GPUQuerySet
+foreign import createQuerySetImpl
+  :: EffectFn2 GPUDevice GPUQuerySetDescriptor GPUQuerySet
+
 createQuerySet :: GPUDevice -> GPUQuerySetDescriptor -> Effect GPUQuerySet
 createQuerySet a b = runEffectFn2 createQuerySetImpl a b
 

--- a/src/Web/GPU/GPUQueue.purs
+++ b/src/Web/GPU/GPUQueue.purs
@@ -18,7 +18,7 @@ module Web.GPU.GPUQueue
   ) where
 
 import Prelude
-import Effect.Uncurried(EffectFn1, runEffectFn1,EffectFn2, runEffectFn2,EffectFn4, runEffectFn4,EffectFn5, runEffectFn5,EffectFn6, runEffectFn6)
+import Effect.Uncurried (EffectFn1, runEffectFn1, EffectFn2, runEffectFn2, EffectFn4, runEffectFn4, EffectFn5, runEffectFn5, EffectFn6, runEffectFn6)
 
 import Effect (Effect)
 import Web.GPU.BufferSource (BufferSource)
@@ -30,38 +30,61 @@ import Web.GPU.GPUImageCopyTextureTagged (GPUImageCopyTextureTagged)
 import Web.GPU.GPUImageDataLayout (GPUImageDataLayout)
 import Web.GPU.Internal.GPUCommandBuffer (GPUCommandBuffer)
 import Web.GPU.Internal.Types (GPUSize64)
-import Web.Promise (Promise)
+import Promise (Promise)
 
 data GPUQueue
 
-foreign import submitImpl :: EffectFn2 GPUQueue (Array GPUCommandBuffer)  Unit
+foreign import submitImpl :: EffectFn2 GPUQueue (Array GPUCommandBuffer) Unit
+
 submit ∷ GPUQueue → Array GPUCommandBuffer → Effect Unit
 submit a b = runEffectFn2 submitImpl a b
 
-foreign import onSubmittedWorkDoneImpl :: EffectFn1 GPUQueue  (Promise Unit)
+foreign import onSubmittedWorkDoneImpl :: EffectFn1 GPUQueue (Promise Unit)
+
 onSubmittedWorkDone :: GPUQueue -> Effect (Promise Unit)
 onSubmittedWorkDone a = runEffectFn1 onSubmittedWorkDoneImpl a
 
-foreign import writeBufferImpl :: EffectFn4 GPUQueue GPUBuffer GPUSize64 BufferSource  Unit
+foreign import writeBufferImpl
+  :: EffectFn4 GPUQueue GPUBuffer GPUSize64 BufferSource Unit
+
 writeBuffer :: GPUQueue -> GPUBuffer -> Int -> BufferSource -> Effect Unit
 writeBuffer a b c d = runEffectFn4 writeBufferImpl a b c d
 
-foreign import writeBufferWithOffsetImpl :: EffectFn5 GPUQueue GPUBuffer GPUSize64 BufferSource GPUSize64  Unit
+foreign import writeBufferWithOffsetImpl
+  :: EffectFn5 GPUQueue GPUBuffer GPUSize64 BufferSource GPUSize64 Unit
+
 writeBufferWithOffset
   :: GPUQueue -> GPUBuffer -> Int -> BufferSource -> Int -> Effect Unit
-writeBufferWithOffset a b c d e = runEffectFn5 writeBufferWithOffsetImpl a b c d e
+writeBufferWithOffset a b c d e = runEffectFn5 writeBufferWithOffsetImpl a b c d
+  e
 
-foreign import writeBufferWithSizeImpl :: EffectFn5 GPUQueue GPUBuffer GPUSize64 BufferSource GPUSize64  Unit
+foreign import writeBufferWithSizeImpl
+  :: EffectFn5 GPUQueue GPUBuffer GPUSize64 BufferSource GPUSize64 Unit
+
 writeBufferWithSize
   :: GPUQueue -> GPUBuffer -> Int -> BufferSource -> Int -> Effect Unit
 writeBufferWithSize a b c d e = runEffectFn5 writeBufferWithSizeImpl a b c d e
 
-foreign import writeBufferWithOffsetAndSizeImpl :: EffectFn6 GPUQueue GPUBuffer GPUSize64 BufferSource GPUSize64 GPUSize64  Unit
+foreign import writeBufferWithOffsetAndSizeImpl
+  :: EffectFn6 GPUQueue GPUBuffer GPUSize64 BufferSource GPUSize64 GPUSize64
+       Unit
+
 writeBufferWithOffsetAndSize
   :: GPUQueue -> GPUBuffer -> Int -> BufferSource -> Int -> Int -> Effect Unit
-writeBufferWithOffsetAndSize a b c d e f = runEffectFn6 writeBufferWithOffsetAndSizeImpl a b c d e f
+writeBufferWithOffsetAndSize a b c d e f = runEffectFn6
+  writeBufferWithOffsetAndSizeImpl
+  a
+  b
+  c
+  d
+  e
+  f
 
-foreign import writeTextureImpl :: EffectFn5 GPUQueue GPUImageCopyTexture BufferSource GPUImageDataLayout GPUExtent3D  Unit
+foreign import writeTextureImpl
+  :: EffectFn5 GPUQueue GPUImageCopyTexture BufferSource GPUImageDataLayout
+       GPUExtent3D
+       Unit
+
 writeTexture
   :: GPUQueue
   -> GPUImageCopyTexture
@@ -71,11 +94,19 @@ writeTexture
   -> Effect Unit
 writeTexture a b c d e = runEffectFn5 writeTextureImpl a b c d e
 
-foreign import copyExternalImageToTextureImpl :: EffectFn4 GPUQueue GPUImageCopyExternalImage GPUImageCopyTextureTagged GPUExtent3D  Unit
+foreign import copyExternalImageToTextureImpl
+  :: EffectFn4 GPUQueue GPUImageCopyExternalImage GPUImageCopyTextureTagged
+       GPUExtent3D
+       Unit
+
 copyExternalImageToTexture
   :: GPUQueue
   -> GPUImageCopyExternalImage
   -> GPUImageCopyTextureTagged
   -> GPUExtent3D
   -> Effect Unit
-copyExternalImageToTexture a b c d = runEffectFn4 copyExternalImageToTextureImpl a b c d
+copyExternalImageToTexture a b c d = runEffectFn4 copyExternalImageToTextureImpl
+  a
+  b
+  c
+  d

--- a/src/Web/GPU/GPUShaderModule.purs
+++ b/src/Web/GPU/GPUShaderModule.purs
@@ -9,11 +9,11 @@ module Web.GPU.GPUShaderModule
   ) where
 
 import Prelude
-import Effect.Uncurried(EffectFn1, runEffectFn1)
+import Effect.Uncurried (EffectFn1, runEffectFn1)
 
 import Effect (Effect)
 import Web.GPU.Internal.Types (UnsignedLongLong)
-import Web.Promise (Promise)
+import Promise (Promise)
 
 data GPUShaderModule
 newtype GPUCompilationMessageType = GPUCompilationMessageType String
@@ -44,6 +44,8 @@ type GPUCompilationInfo =
   { messages :: Array GPUCompilationMessage
   }
 
-foreign import compilationInfoImpl :: EffectFn1 GPUShaderModule  (Promise GPUCompilationInfo)
+foreign import compilationInfoImpl
+  :: EffectFn1 GPUShaderModule (Promise GPUCompilationInfo)
+
 compilationInfo :: GPUShaderModule -> Effect (Promise GPUCompilationInfo)
 compilationInfo a = runEffectFn1 compilationInfoImpl a


### PR DESCRIPTION
The `web-promise` library is being deprecated in favor of the node/web shared `js-promise` library. This PR updates webgpu to use js-promise instead of web-promise, so it can remain in the package sets after web-promise is removed.